### PR TITLE
Fixed the recursion issue in Visitor

### DIFF
--- a/src/main/java/com/github/sirnoob97/jdup/Visitor.java
+++ b/src/main/java/com/github/sirnoob97/jdup/Visitor.java
@@ -19,10 +19,9 @@ public class Visitor {
         return ignore.contains(dir.getFileName().toString()) ? FileVisitResult.SKIP_SIBLINGS : CONTINUE;
       }
 
-      // TODO: Fix the recursion problem, when the file is a directory the children are never visited
       @Override
       public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-        if(!Files.isDirectory(file)) files.add(file);
+        files.add(file);
         return CONTINUE;
       }
 


### PR DESCRIPTION
While doing some tests, it seems that the code works fine without the condition checking if _file_ is not a directory and should fix the issue of not checking some folders. Feel free to let me know if there is some case where this couldn't work in some way.